### PR TITLE
chore: remove node 10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Austin McGee <austin@dhis2.org>",
     "license": "BSD-3-Clause",
     "engines": {
-        "node": ">=10"
+        "node": ">=12"
     },
     "dependencies": {
         "@dhis2/cli-helpers-engine": "^1.5.0",


### PR DESCRIPTION
BREAKING CHANGE: New minimum version for NodeJS is 12.x.
